### PR TITLE
Fix LIBTD-442: make 'rights' as required field for a Collection; 'rig…

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,2 +1,7 @@
 class Collection < Sufia::Collection
+  validates :rights, presence: true
+
+  property :rights, predicate: ::RDF::Vocab::DC.rights, multiple: false do |index|
+    index.as :stored_searchable
+  end
 end

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :rights, as: :select_with_help, collection: Sufia.config.cc_licenses,
+    input_html: { class: 'form-control', multiple: false }, required: f.object.required?(key)
+  %>
+<%= render "generic_files/rights_modal" %>


### PR DESCRIPTION
…hts' has been a Sufia default required field for a GenericFile
